### PR TITLE
race fixes (#94)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: 1.16
 
       - name: Test
-        run: go test -coverprofile=coverage.out ./...
+        run: go test -race -coverprofile=coverage.out ./...
 
       - name: Convert coverage
         uses: jandelgado/gcov2lcov-action@v1.0.5

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default: services test
 
 .PHONY: test
 test:
-	go test ./...
+	go test -race ./...
 
 .PHONY: lint
 lint:

--- a/fsm.go
+++ b/fsm.go
@@ -349,6 +349,7 @@ func (f *FSM) Event(ctx context.Context, event string, args ...interface{}) erro
 
 			f.stateMu.Lock()
 			f.current = dst
+			f.transition = nil // treat the state transition as done
 			f.stateMu.Unlock()
 
 			// at this point, we unlock the event mutex in order to allow
@@ -359,7 +360,6 @@ func (f *FSM) Event(ctx context.Context, event string, args ...interface{}) erro
 				f.eventMu.Unlock()
 				unlocked = true
 			}
-			f.transition = nil // treat the state transition as done
 			f.enterStateCallbacks(ctx, e)
 			f.afterEventCallbacks(ctx, e)
 		}
@@ -420,7 +420,6 @@ func (t transitionerStruct) transition(f *FSM) error {
 		return NotInTransitionError{}
 	}
 	f.transition()
-	f.transition = nil
 	return nil
 }
 


### PR DESCRIPTION
* race fixes

* race flag

* ci race flag

* update transition within state mutex, this prevents races at Can calls

---------

Co-authored-by: Emin Tasgetiren <emin.tasgetiren@abex.capital>